### PR TITLE
Complete unqualified image names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ $(KUBECTL):
 	chmod +x $@
 
 set-manifest-image:
-	sed -i'' -e 's@image: .*@image: '"${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./k8s/manifest.yaml >> ./k8s/manifest.yaml-e
+	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./k8s/manifest.yaml >> ./k8s/manifest.yaml-e
 	cp ./k8s/manifest.yaml ./manifest/manifest.yaml
 
 .PHONY: manifests

--- a/k8s/manifest.yaml
+++ b/k8s/manifest.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
       - command:
         - /conversion-webhook
-        image: projectsveltos/webhook-conversion:main
+        image: docker.io/projectsveltos/webhook-conversion:main
         name: sveltos-webhook
         ports:
         - containerPort: 9443

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
       - command:
         - /conversion-webhook
-        image: projectsveltos/webhook-conversion:main
+        image: docker.io/projectsveltos/webhook-conversion:main
         name: sveltos-webhook
         ports:
         - containerPort: 9443


### PR DESCRIPTION
Add 'docker.io' registry server name where missing.

That allows applications to run on CRIs not configured to handle unqualified registries.